### PR TITLE
Fix `cref` to `Void` in `Unit` doc remarks

### DIFF
--- a/src/Eff/Unit.cs
+++ b/src/Eff/Unit.cs
@@ -6,7 +6,7 @@ namespace Nessos.Effects
     ///   A type inhabited by a single value.
     /// </summary>
     /// <remarks>
-    ///   While similar to <see cref="void"/>, the unit type is inhabited 
+    ///   While similar to <see cref="Void"/>, the unit type is inhabited 
     ///   by a single materialized value and can be used as a generic parameter.
     /// </remarks>
     public readonly struct Unit : IEquatable<Unit>


### PR DESCRIPTION
This PR fixes a typo in XML documentation of `Unit`. The type called out in the `cref` of [`<see>`](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/xmldoc/recommended-tags#see) should read `Void` (to refer to [`System.Void`](https://learn.microsoft.com/en-us/dotnet/api/system.void?view=net-8.0)). Alternatively, to use `void`, one could say `<see langversion="void" />`.